### PR TITLE
Patch 2

### DIFF
--- a/mini_Tutorial.md
+++ b/mini_Tutorial.md
@@ -264,7 +264,6 @@ are defined.
 
 Once the jars are downloaded, head over to the downloaded wdlfilter directory and run
 ```
-mkdir filtered_fastas
 cd wdlfilter/
 java -jar /path/to/womtool-34.jar inputs FilterDomain.wdl > viral.inputs.json 
 ```

--- a/mini_Tutorial.md
+++ b/mini_Tutorial.md
@@ -192,7 +192,7 @@ of the script.
 
 ``` 
 $ python annotate_tree.py -t 10239 \
--db /path/to/ete3_db \
+-db /path/to/ete3_db/ \
 -j /path/to/Refseq90.DNA.json \
 -r viruses.family.svg \
 -prune family 


### PR DESCRIPTION
Maybe specify to the user that the taxa.sqlite file is being made when referencing to it and the same goes for the `outputDir` for the filtered fastas.